### PR TITLE
CLI for multiple voices doesn't accept "filename-last" format #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ optional arguments:
 When developing, you probably want the python requirements to be installed in a virtual env. We
 assume you name this `mpt_venv`.
 
-```
+```bash
 $ python3 -m venv mtp_venv
 $ source mpt_venv/bin/activate
 $ pip3 install -r requirements.txt
@@ -90,7 +90,11 @@ First install [autopep8](https://pypi.org/project/autopep8/) `$ pip3 install aut
 
 ### Tests
 
-`$ python3 tests/test-integration.py`
+```bash
+$ python3 tests/test_argument_parser.py
+$ python3 tests/test_more_voices.py
+$ python3 tests/test_integration.py
+```
 
 ### Available fixtures
 

--- a/midi_to_part_mp3s.py
+++ b/midi_to_part_mp3s.py
@@ -47,7 +47,7 @@ def check_format(file_path: str) -> str:
     """
     if file_path.endswith('.mid') or file_path.endswith('.midi'):
         return file_path
-    elif file_path.endswith('.mxl'):
+    elif file_path.endswith('.mxl') or file_path.endswith('.musicxml'):
         return convert_music_xml_to_midi(file_path)
     else:
         raise NameError(
@@ -322,27 +322,39 @@ def set_defaults(args: argparse.Namespace) -> None:
         args.alto = [2]
         args.tenor = [3]
         args.bass = [4]
+    else:
+        if args.soprano:
+            args.soprano = [int(track) for track in args.soprano.split(',')]
+        if args.alto:
+            args.alto = [int(track) for track in args.alto.split(',')]
+        if args.tenor:
+            args.tenor = [int(track) for track in args.tenor.split(',')]
+        if args.bass:
+            args.bass = [int(track) for track in args.bass.split(',')]
 
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
-    parser.add_argument("-s", "--soprano", type=int,
-                        help='defaults to 1', nargs='*')
-    parser.add_argument("-a", "--alto", type=int,
-                        help='defaults to 2', nargs='*')
-    parser.add_argument("-t", "--tenor", type=int,
-                        help='defaults to 3', nargs='*')
-    parser.add_argument("-b", "--bass", type=int,
-                        help='defaults to 4', nargs='*')
+    parser.add_argument("-s", "--soprano", type=str,
+                        help='comma separated list of midi track IDs, defaults to "1"')
+    parser.add_argument("-a", "--alto", type=str,
+                        help='comma separated list of midi track IDs, defaults to "2"')
+    parser.add_argument("-t", "--tenor", type=str,
+                        help='comma separated list of midi track IDs, defaults to "3"')
+    parser.add_argument("-b", "--bass", type=str,
+                        help='comma separated list of midi track IDs, defaults to "4"')
     parser.add_argument("-in", "--instrument", type=int,
-                        help=('instrument that should be used for all voices instead ' +
-                              'of the advice given at cpdl.org'))
+                        help=('instrument that should be used for all voices instead \
+                              of the advice given at cpdl.org'))
     parser.add_argument("-iv", "--instrumental-volume",
                         help="configure instrumental volume", type=float, default=2.0)
     parser.add_argument("-i", "--instrumental-accompaniment", help='midi tracks that \
           appear in all accompaniment mp3s e.g. piano or orchestra', nargs='+',
                         type=int, default=[])
-    parser.add_argument("file_path")
+    requiredNamed = parser.add_argument_group('mandatory argument')
+    requiredNamed.add_argument("-f", "--file-path", required=True,
+                               help='Input file to generate the tracks from. Can be Midi or \
+                            MusicXML (.mid, .midi, .mxl, .musicxml)')
     return parser
 
 

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -1,0 +1,38 @@
+import unittest
+import shutil
+import argparse
+import os
+from typing import List
+
+
+# allow to import modules from parent dir (https://stackoverflow.com/a/33532002/2641951)
+from inspect import getsourcefile
+import os.path as path
+import sys
+current_dir = path.dirname(path.abspath(getsourcefile(lambda: 0)))
+sys.path.insert(0, current_dir[:current_dir.rfind(path.sep)])
+import midi_to_part_mp3s
+
+class TestArgumentParser(unittest.TestCase):
+
+    def test_comma_separated(self):
+        args = self.parse_arguments_set_defaults(
+            ['-f', 'my_midi.mid', '-s', '1,2,3', '-a', '4', '-t', '7,8'])
+        self.assertEqual(args.file_path, 'my_midi.mid')
+        self.assertEqual(len(args.soprano), 3)
+        self.assertCountEqual(args.soprano, [1, 2, 3])
+        self.assertEqual(len(args.alto), 1)
+        self.assertCountEqual(args.alto, [4])
+        self.assertEqual(len(args.tenor), 2)
+        self.assertCountEqual(args.tenor, [7, 8])
+        self.assertEqual(args.bass, None)
+
+    def parse_arguments_set_defaults(self, argument_list: List[str]) -> argparse.Namespace:
+        parser = midi_to_part_mp3s.get_parser()
+        args = parser.parse_args(argument_list)
+        midi_to_part_mp3s.set_defaults(args)
+        return args
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,7 @@ class TestIntegration(unittest.TestCase):
             shutil.rmtree(output_directory)
 
     def test_conversion_of_midi_with_separate_tempo_map(self):
-        midi_file_path = "./tests/fixtures/Schumann-op67-4.mid"
+        midi_file_path = "-f ./tests/fixtures/Schumann-op67-4.mid"
         cmd = "./midi-to-part-mp3s {}".format(midi_file_path)
         os.system(cmd)
 
@@ -25,7 +25,7 @@ class TestIntegration(unittest.TestCase):
         self.assertTrue(os.path.isfile(all_parts_mp3_output))
 
     def test_midi_without_separate_tempo_map(self):
-        midi_file_path = "./tests/fixtures/Brahms-Da-unten-im-Tale.mid"
+        midi_file_path = "-f ./tests/fixtures/Brahms-Da-unten-im-Tale.mid"
         cmd = "./midi-to-part-mp3s {}".format(midi_file_path)
         os.system(cmd)
 

--- a/tests/test_more_voices.py
+++ b/tests/test_more_voices.py
@@ -27,7 +27,8 @@ class TestMoreVoices(unittest.TestCase):
         return super().tearDown()
 
     def test_defaut_settings(self):
-        arguments: List[str] = ["./tests/fixtures/Brahms-Da-unten-im-Tale.mid"]
+        arguments: List[str] = [
+            "-f", "./tests/fixtures/Brahms-Da-unten-im-Tale.mid"]
         expected_filenames = ['tenor 1 with accompaniment.mp3', 'soprano 1.mp3',
                               'tenor 1.mp3', 'bass 1.mp3', 'soprano 1 with accompaniment.mp3',
                               'alto 1 with accompaniment.mp3', 'alto 1.mp3', 'all.mp3',
@@ -35,8 +36,8 @@ class TestMoreVoices(unittest.TestCase):
         self._simple_file_list_check(arguments, expected_filenames)
 
     def test_ssaa(self):
-        arguments: List[str] = ["./tests/fixtures/Brahms-Da-unten-im-Tale.mid",
-                                '--soprano', '1', '2', '--alto', '3', '4']
+        arguments: List[str] = ["-f", "./tests/fixtures/Brahms-Da-unten-im-Tale.mid",
+                                '--soprano', '1,2', '--alto', '3,4']
         expected_filenames = ['soprano 1.mp3', 'soprano 1 with accompaniment.mp3',
                               'soprano 2.mp3', 'soprano 2 with accompaniment.mp3',
                               'alto 1.mp3', 'alto 1 with accompaniment.mp3',
@@ -45,9 +46,9 @@ class TestMoreVoices(unittest.TestCase):
         self._simple_file_list_check(arguments, expected_filenames)
 
     def test_ssaattbb(self):
-        arguments: List[str] = ["./tests/fixtures/Abendlied-Rheinberger.mxl",
-                                '--soprano', '1', '2', '--alto', '3', '4',
-                                '--tenor', '5', '6', '--bass', '7', '8']
+        arguments: List[str] = ["-f", "./tests/fixtures/Abendlied-Rheinberger.mxl",
+                                '--soprano', '1,2', '--alto', '3,4',
+                                '--tenor', '5,6', '--bass', '7,8']
         expected_filenames = ['soprano 1.mp3', 'soprano 1 with accompaniment.mp3',
                               'soprano 2.mp3', 'soprano 2 with accompaniment.mp3',
                               'alto 1.mp3', 'alto 1 with accompaniment.mp3',


### PR DESCRIPTION
filename-last problem solved by using -f
Midi tracks per voice can now be defined in a comma separated list
Added unittest for argument parser
renamed test-integration.py to test_integration.py to follow naming schema